### PR TITLE
bump bare-metal dependency and enable its const-fn feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,5 +9,6 @@ name = "msp430"
 repository = "https://github.com/pftbest/msp430"
 version = "0.1.0"
 
-[dependencies]
-bare-metal = "0.1.0"
+[dependencies.bare-metal]
+features = ["const-fn"]
+version = "0.2.0"


### PR DESCRIPTION
this removes the const_fn feature gate from that dependency

the downside is that it bumps the toolchain version requirement of this
crate (~4 weeks old nightly or newer) so you may want to bump the minor version
in the next release

r? @cr1901