### PR TITLE
Bump minor version to take advantage of bare_metal 0.2.x on crates.io…

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ before_install: set -e
 
 install:
   - bash ci/install.sh
-  - export PATH="$PATH:$PWD/msp430-gcc-7.3.2.154_linux64/bin"
+  - export PATH="$PATH:$PWD/msp430-gcc-8.3.1.25_linux64/bin"
 
 script:
   - bash ci/script.sh

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,4 +7,15 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
-[Unreleased]: https://github.com/pftbest/msp430/compare/v0.1.0...HEAD
+## [v0.1.1] - 2019-12-22
+
+Updated bare_metal to 0.2.x. The crate's API is compatible with 0.1.0, but
+using bare_metal 0.2.x consistently decreases multiple versions of the same
+crate in the dependency graph.
+
+## v0.1.0 - 2017-07-22
+
+Initial release.
+
+[Unreleased]: https://github.com/pftbest/msp430/compare/v0.1.1...HEAD
+[v0.1.1]: https://github.com/pftbest/msp430/compare/v0.1.0...v0.1.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,15 +7,15 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
-## [v0.1.1] - 2019-12-22
+## [v0.2.0] - 2019-12-26
 
 Updated bare_metal to 0.2.x. The crate's API is compatible with 0.1.0, but
-using bare_metal 0.2.x consistently decreases multiple versions of the same
-crate in the dependency graph.
+using bare_metal v0.2.x causes incompatible type errors with device crates
+(PACs) using bare_metal v0.1.x. This requires a major version bump to fix.
 
 ## v0.1.0 - 2017-07-22
 
 Initial release.
 
-[Unreleased]: https://github.com/pftbest/msp430/compare/v0.1.1...HEAD
-[v0.1.1]: https://github.com/pftbest/msp430/compare/v0.1.0...v0.1.1
+[Unreleased]: https://github.com/pftbest/msp430/compare/v0.2.0...HEAD
+[v0.2.0]: https://github.com/pftbest/msp430/compare/v0.1.0...v0.2.0

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ keywords = ["msp430", "interrupt", "register", "peripheral"]
 license = "MIT OR Apache-2.0"
 name = "msp430"
 repository = "https://github.com/pftbest/msp430"
-version = "0.1.1"
+version = "0.2.0"
 
 [dependencies.bare-metal]
 features = ["const-fn"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ keywords = ["msp430", "interrupt", "register", "peripheral"]
 license = "MIT OR Apache-2.0"
 name = "msp430"
 repository = "https://github.com/pftbest/msp430"
-version = "0.1.0"
+version = "0.1.1"
 
 [dependencies.bare-metal]
 features = ["const-fn"]

--- a/ci/install.sh
+++ b/ci/install.sh
@@ -8,9 +8,8 @@ main() {
 
             rustup component add rust-src
 
-            local file=msp430-gcc-7.3.2.154_linux64.7z
-            curl -LO http://software-dl.ti.com/msp430/msp430_public_sw/mcu/msp430/MSPGCC/latest/exports/$file
-            7zr x $file
+            curl -LO http://software-dl.ti.com/msp430/msp430_public_sw/mcu/msp430/MSPGCC/8_3_1_0/export/msp430-gcc-8.3.1.25_linux64.tar.bz2
+            tar xjf msp430-gcc-8.3.1.25_linux64.tar.bz2
             ;;
     esac
 }


### PR DESCRIPTION
…. Update CHANGELOG.md.

cc: @pftbest, @awygle, @YuhanLiin I want a second pair of eyes on this. The reason for the version bump now is that I want `bare_metal 0.2.x` to be consistently used in my msp430 code, rather than having copies of `bare_metal 0.1.x` strewn about as well.

I think this technically constitutes a minor version bump