### PR TITLE
Add options to asm

### DIFF
--- a/src/asm.rs
+++ b/src/asm.rs
@@ -3,17 +3,23 @@
 use crate::asm;
 
 /// A no-operation. Useful to prevent delay loops from being optimized away.
+///
+/// Unlike [barrier], this does not prevent reordering of memory access.
 #[inline(always)]
 pub fn nop() {
     unsafe {
-        asm!("nop");
+        // Do not use pure because prevent nop from being removed.
+        asm!("nop", options(nomem, nostack, preserves_flags));
     }
 }
 
 /// A compiler fence, prevents instruction reordering.
+///
+/// Unlike [nop], this does not emit machine code.
 #[inline(always)]
 pub fn barrier() {
     unsafe {
-        asm!("");
+        // Do not use `nomem` and `readonly` because prevent preceding and subsequent memory accesses from being reordered.
+        asm!("", options(nostack, preserves_flags));
     }
 }

--- a/src/interrupt.rs
+++ b/src/interrupt.rs
@@ -10,7 +10,9 @@ pub fn disable() {
     match () {
         #[cfg(target_arch = "msp430")]
         () => unsafe {
-            asm!("dint {{ nop");
+            // Do not use `nomem` and `readonly` because prevent subsequent memory accesses from being reordered before interrupts are disabled.
+            // Do not use `preserves_flags` because DINT modifies the GIE (global interrupt enable) bit of the status register.
+            asm!("dint {{ nop", options(nostack));
         },
         #[cfg(not(target_arch = "msp430"))]
         () => {}
@@ -29,7 +31,9 @@ pub unsafe fn enable() {
     match () {
         #[cfg(target_arch = "msp430")]
         () => {
-            asm!("nop {{ eint {{ nop");
+            // Do not use `nomem` and `readonly` because prevent preceding memory accesses from being reordered after interrupts are enabled.
+            // Do not use `preserves_flags` because EINT modifies the GIE (global interrupt enable) bit of the status register.
+            asm!("nop {{ eint {{ nop", options(nostack));
         }
         #[cfg(not(target_arch = "msp430"))]
         () => {}

--- a/src/register/pc.rs
+++ b/src/register/pc.rs
@@ -7,7 +7,7 @@ use crate::asm;
 pub fn read() -> u16 {
     let r;
     unsafe {
-        asm!("mov R0, {0}", out(reg) r);
+        asm!("mov R0, {0}", out(reg) r, options(nomem, nostack, preserves_flags));
     }
     r
 }

--- a/src/register/sp.rs
+++ b/src/register/sp.rs
@@ -7,7 +7,7 @@ use crate::asm;
 pub fn read() -> u16 {
     let r;
     unsafe {
-        asm!("mov R1, {0}", out(reg) r);
+        asm!("mov R1, {0}", out(reg) r, options(nomem, nostack, preserves_flags));
     }
     r
 }

--- a/src/register/sr.rs
+++ b/src/register/sr.rs
@@ -79,7 +79,7 @@ impl Sr {
 pub fn read() -> Sr {
     let r: u16;
     unsafe {
-        asm!("mov R2, {0}", out(reg) r);
+        asm!("mov R2, {0}", out(reg) r, options(nomem, nostack, preserves_flags));
     }
     Sr { bits: r }
 }


### PR DESCRIPTION
- Use `nomem` when neither memory access nor reordering prevention is needed.
- Use `nostack` when not pushing data to the stack.
- Use `preserves_flags` when not modifying the status register.
  refs: https://doc.rust-lang.org/nightly/unstable-book/language-features/asm-experimental-arch.html#flags-covered-by-preserves_flags
- Add comments explaining why specific options are not used.

refs: https://doc.rust-lang.org/nightly/reference/inline-assembly.html#options

cc #11
cc @cr1901
